### PR TITLE
Better performance and code readability

### DIFF
--- a/snakecase.go
+++ b/snakecase.go
@@ -4,18 +4,23 @@ import (
 	"unicode"
 )
 
-// ToSnake convert the given string to snake case following the Golang format:
+// SnakeCase converts the given string to snake case following the Golang format:
 // acronyms are converted to lower-case and preceded by an underscore.
-func SnakeCase(in string) string {
-	runes := []rune(in)
-	length := len(runes)
+func SnakeCase(s string) string {
+	in := []rune(s)
+	isLower := func(idx int) bool {
+		return idx >= 0 && idx < len(in) && unicode.IsLower(in[idx])
+	}
 
-	var out []rune
-	for i := 0; i < length; i++ {
-		if i > 0 && unicode.IsUpper(runes[i]) && ((i+1 < length && unicode.IsLower(runes[i+1])) || unicode.IsLower(runes[i-1])) && runes[i-1] != '_' {
-			out = append(out, '_')
+	out := make([]rune, 0, len(in)+len(in)/2)
+	for i, r := range in {
+		if unicode.IsUpper(r) {
+			r = unicode.ToLower(r)
+			if i > 0 && in[i-1] != '_' && (isLower(i-1) || isLower(i+1)) {
+				out = append(out, '_')
+			}
 		}
-		out = append(out, unicode.ToLower(runes[i]))
+		out = append(out, r)
 	}
 
 	return string(out)


### PR DESCRIPTION
```
BenchmarkSnakeCase-8          500000          2533 ns/op         592 B/op         20 allocs/op
BenchmarkToLower-8           1000000          1256 ns/op         128 B/op         14 allocs/op
BenchmarkSnakeCaseOrig-8      500000          3531 ns/op         928 B/op         41 allocs/op
```
